### PR TITLE
WD-164: Falha ao realizar deploy usando action-deploy-sp

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,11 @@
 name: Testing Action
-on: push
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+    branches:
+      - "main"
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Atualmente a action de testes configurada não permite ser disparada manualmente.
Para não realizar alterações errôneas ou desnecessárias e mandá-las para a `main`, é importante que a action de testes possa ser disparada a partir da branch WD-164 até que tudo seja devidamente resolvido.